### PR TITLE
Add feature admin application show page with pet accept and reject buttons

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,13 @@
+class AdminController < ApplicationController
+  def show
+    @application = Application.find(params[:id])
+  end
+
+  def update
+    @application = Application.find(params[:app_id])
+    app_pet = @application.application_pets.find(params[:pet_id])
+    app_pet.update(status: params[:status].to_i)
+
+    redirect_to "/admin/applications/#{params[:app_id]}"
+  end
+end

--- a/app/models/application_pet.rb
+++ b/app/models/application_pet.rb
@@ -1,4 +1,5 @@
 class ApplicationPet < ApplicationRecord
   belongs_to :pet
   belongs_to :application
+  enum status: [:pending, :accepted, :rejected]
 end

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,0 +1,15 @@
+<%= content_tag :h1, "#{@application.user_name}'s Application'" %>
+
+<%= content_tag :h3, "Application Pets:" %>
+<ul>
+<% @application.application_pets.each do |application_pet| %>
+  <li id='pet-application-status-<%= application_pet.pet.id %>'>
+    <%= content_tag :p, application_pet.pet.name %>
+    <% if application_pet.status == 'pending'  %>
+      <%= button_to "Approve Pet", "/admin/application/#{@application.id}/application_pets/#{application_pet.id}", method: :patch, params: {status: 1} %>
+    <% else %>
+      <%= application_pet.status %>
+    <% end %>
+  </li>
+<% end %>
+</ul>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -7,6 +7,7 @@
     <%= content_tag :p, application_pet.pet.name %>
     <% if application_pet.status == 'pending'  %>
       <%= button_to "Approve Pet", "/admin/application/#{@application.id}/application_pets/#{application_pet.id}", method: :patch, params: {status: 1} %>
+      <%= button_to "Reject Pet", "/admin/application/#{@application.id}/application_pets/#{application_pet.id}", method: :patch, params: {status: 2} %>
     <% else %>
       <%= application_pet.status %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,8 @@ Rails.application.routes.draw do
   get '/applications/:id', to: 'applications#show'
   post '/applications', to: 'applications#create'
   patch '/applications/:id', to: 'applications#update'
+
+  # ADMIN
+  get '/admin/applications/:id', to: 'admin#show'
+  patch '/admin/application/:app_id/application_pets/:pet_id', to: 'admin#update'
 end

--- a/db/migrate/20201019220123_add_status_to_application_pets.rb
+++ b/db/migrate/20201019220123_add_status_to_application_pets.rb
@@ -1,0 +1,5 @@
+class AddStatusToApplicationPets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :application_pets, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_16_230815) do
+ActiveRecord::Schema.define(version: 2020_10_19_220123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2020_10_16_230815) do
   create_table "application_pets", force: :cascade do |t|
     t.bigint "application_id"
     t.bigint "pet_id"
+    t.integer "status", default: 0
     t.index ["application_id"], name: "index_application_pets_on_application_id"
     t.index ["pet_id"], name: "index_application_pets_on_pet_id"
   end

--- a/spec/features/admin/application_show_spec.rb
+++ b/spec/features/admin/application_show_spec.rb
@@ -12,7 +12,7 @@ describe "As a visitor" do
       @application.application_pets.create([{pet_id: @pet1.id}, {pet_id: @pet2.id}])
       visit "/admin/applications/#{@application.id}"
     end
-    it "I see a button for every pet to approve the application for that pet" do
+    it "I see a button for every pet to approve that pet for the application" do
       within("#pet-application-status-#{@pet1.id}") do
         expect(page).to have_button("Approve Pet")
       end
@@ -30,6 +30,26 @@ describe "As a visitor" do
         click_button "Approve Pet"
         expect(page).to have_content("accepted")
         expect(page).to_not have_button("Approve Pet")
+      end
+    end
+    it "I see a button for every pet to reject that pet for the application" do
+      within("#pet-application-status-#{@pet1.id}") do
+        expect(page).to have_button("Reject Pet")
+      end
+      within("#pet-application-status-#{@pet2.id}") do
+        expect(page).to have_button("Reject Pet")
+      end
+    end
+    it "When I click that button, I'm taken back to the admin application show page and next to the pet I rejected, I see an rejection indicator next to the pet instead of an reject button" do
+      within("#pet-application-status-#{@pet1.id}") do
+        click_button "Reject Pet"
+        expect(page).to have_content("rejected")
+        expect(page).to_not have_button("Reject Pet")
+      end
+      within("#pet-application-status-#{@pet2.id}") do
+        click_button "Reject Pet"
+        expect(page).to have_content("rejected")
+        expect(page).to_not have_button("Reject Pet")
       end
     end
   end

--- a/spec/features/admin/application_show_spec.rb
+++ b/spec/features/admin/application_show_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe "As a visitor" do
+  describe "When I visit an admin applicaiton show page ('/admin/applications/:id')" do
+    before :each do
+      @shelter1 = Shelter.create(name: "Van's pet shop", address: "3724 tennessee dr", city: "Rockford", state: "Illinois", zip: "61108")
+      @shelter2 = Shelter.create(name: "Bovice's pet shop", address: "1060 W Addison", city: "Chicago", state: "Illinois", zip: "61109")
+      @pet1 = @shelter1.pets.create(image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", name: "Bella", age: "5", sex: "female", description: "Fun Loving Dog", status: 0)
+      @pet2 = @shelter2.pets.create(image: "https://static.insider.com/image/5d24d6b921a861093e71fef3.jpg", name: "Maisy", age: "6", sex: "female", description: "Stomache on legs", status: 0)
+      @user = User.create!(name: "Tim Tyrell", address: "321 you hate to see it dr", city: "Denver", state: "Colorado", zip: "80000")
+      @application = @user.applications.create(description: "I'm awesome, give me animals.", status: 1)
+      @application.application_pets.create([{pet_id: @pet1.id}, {pet_id: @pet2.id}])
+      visit "/admin/applications/#{@application.id}"
+    end
+    it "I see a button for every pet to approve the application for that pet" do
+      within("#pet-application-status-#{@pet1.id}") do
+        expect(page).to have_button("Approve Pet")
+      end
+      within("#pet-application-status-#{@pet2.id}") do
+        expect(page).to have_button("Approve Pet")
+      end
+    end
+    it "When I click that button, I'm taken back to the admin application show page and next to the pet I approved, I see an approval indicator next to the pet instead of an approaval button" do
+      within("#pet-application-status-#{@pet1.id}") do
+        click_button "Approve Pet"
+        expect(page).to have_content("accepted")
+        expect(page).to_not have_button("Approve Pet")
+      end
+      within("#pet-application-status-#{@pet2.id}") do
+        click_button "Approve Pet"
+        expect(page).to have_content("accepted")
+        expect(page).to_not have_button("Approve Pet")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added features for an admin to review applications and approve or reject pets from the application.
---
- Add tests for application pet approval button
- Add status column to application_pets table
- Add application_pets status enum
- Add show and update routes
- Add show and update actions for admin applications
- Add admin application show page with application pets and pet approval buttons and status
- Add feature tests for pet rejection button and indicator
- Add pet rejection button and indicator