### PR TITLE
Add feature to accept or reject full application

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,8 +7,10 @@ class AdminController < ApplicationController
     @application = Application.find(params[:app_id])
     app_pet = @application.application_pets.find(params[:pet_id])
     app_pet.update(status: params[:status].to_i)
+
     @application.update(status: 2) if @application.application_approved?
-    
+    @application.update(status: 3) if @application.application_rejected?
+
     redirect_to "/admin/applications/#{params[:app_id]}"
   end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,7 +7,8 @@ class AdminController < ApplicationController
     @application = Application.find(params[:app_id])
     app_pet = @application.application_pets.find(params[:pet_id])
     app_pet.update(status: params[:status].to_i)
-
+    @application.update(status: 2) if @application.application_approved?
+    
     redirect_to "/admin/applications/#{params[:app_id]}"
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -2,7 +2,7 @@ class Application < ApplicationRecord
   belongs_to :user
   has_many :application_pets
   has_many :pets, through: :application_pets
-  enum status: [:in_progress, :pending, :accepted, :rejected]
+  enum status: [:in_progress, :pending, :approved, :rejected]
 
   def user_name
     user.name
@@ -14,5 +14,9 @@ class Application < ApplicationRecord
 
   def pet_names
     pets.select(:id, :name)
+  end
+
+  def application_approved?
+    application_pets.pluck(:status).all?('accepted')
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -19,4 +19,8 @@ class Application < ApplicationRecord
   def application_approved?
     application_pets.pluck(:status).all?('accepted')
   end
+
+  def application_rejected?
+    application_pets.pluck(:status).any?('rejected')
+  end
 end

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,6 +1,9 @@
-<%= content_tag :h1, "#{@application.user_name}'s Application'" %>
+<%= content_tag :h1, "#{@application.user_name}'s Application" %>
 
-<%= content_tag :h3, "Application Pets:" %>
+<%= content_tag :p,"Applicant: #{@application.user_name}" %>
+<%= content_tag :p, "Address: #{@application.full_address}" %>
+<%= content_tag :p, "Status: #{@application.status}" %>
+<%= content_tag :p, "Application Pets:" %>
 <ul>
 <% @application.application_pets.each do |application_pet| %>
   <li id='pet-application-status-<%= application_pet.pet.id %>'>

--- a/spec/features/admin/application_show_spec.rb
+++ b/spec/features/admin/application_show_spec.rb
@@ -69,5 +69,20 @@ describe "As a visitor" do
         expect(page).to have_content("Status: approved")
       end
     end
+    describe "and I reject one or more pets on the application, but approve all other pets" do
+      it "then I am taken back to the admin application show page and I see the application's status has changet to 'rejected'" do
+        expect(page).to have_content("Status: pending")
+
+        within("#pet-application-status-#{@pet1.id}") do
+          click_button "Reject Pet"
+        end
+
+        within("#pet-application-status-#{@pet2.id}") do
+          click_button "Approve Pet"
+        end
+
+        expect(page).to have_content("Status: rejected")
+      end
+    end
   end
 end

--- a/spec/features/admin/application_show_spec.rb
+++ b/spec/features/admin/application_show_spec.rb
@@ -52,5 +52,22 @@ describe "As a visitor" do
         expect(page).to_not have_button("Reject Pet")
       end
     end
+    describe "and I approve all pets for and application" do
+      it "then I am taken back to the admin application show page and I see the applications's status has changed to 'approved'" do
+        expect(page).to have_content("Status: pending")
+
+        within("#pet-application-status-#{@pet1.id}") do
+          click_button "Approve Pet"
+        end
+
+        expect(page).to have_content("Status: pending")
+
+        within("#pet-application-status-#{@pet2.id}") do
+          click_button "Approve Pet"
+        end
+
+        expect(page).to have_content("Status: approved")
+      end
+    end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -31,5 +31,24 @@ describe Application, type: :model do
 
       expect(application.pet_names).to eq([pet1, pet2, pet3, pet4])
     end
+    it "#application_approved?" do
+      user = User.create!(name: "Tim Tyrell", address: "321 you hate to see it dr", city: "Denver", state: "Colorado", zip: "80000")
+      shelter = Shelter.create(name: "Van's pet shop", address: "3724 tennessee dr", city: "Rockford", state: "Illinois", zip: "61108")
+      pet1 = shelter.pets.create(image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", name: "Bella", age: "5", sex: "female", description: "Fun Loving Dog", status: 0)
+      pet2 = shelter.pets.create(image: "https://static.insider.com/image/5d24d6b921a861093e71fef3.jpg", name: "Maisy", age: "6", sex: "female", description: "Stomache on legs", status: 0)
+      application = user.applications.create(description: "I'm awesome, give me animals.", status: 1)
+      app_pet1 = application.application_pets.create(pet_id: pet1.id)
+      app_pet2 =application.application_pets.create(pet_id: pet2.id)
+
+      expect(application.application_approved?).to eq(false)
+
+      app_pet1.update(status: 1)
+
+      expect(application.application_approved?).to eq(false)
+
+      app_pet2.update(status: 1)
+
+      expect(application.application_approved?).to eq(true)
+    end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -50,5 +50,24 @@ describe Application, type: :model do
 
       expect(application.application_approved?).to eq(true)
     end
+    it "#application_rejected?" do
+      user = User.create!(name: "Tim Tyrell", address: "321 you hate to see it dr", city: "Denver", state: "Colorado", zip: "80000")
+      shelter = Shelter.create(name: "Van's pet shop", address: "3724 tennessee dr", city: "Rockford", state: "Illinois", zip: "61108")
+      pet1 = shelter.pets.create(image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", name: "Bella", age: "5", sex: "female", description: "Fun Loving Dog", status: 0)
+      pet2 = shelter.pets.create(image: "https://static.insider.com/image/5d24d6b921a861093e71fef3.jpg", name: "Maisy", age: "6", sex: "female", description: "Stomache on legs", status: 0)
+      application = user.applications.create(description: "I'm awesome, give me animals.", status: 1)
+      app_pet1 = application.application_pets.create(pet_id: pet1.id)
+      app_pet2 =application.application_pets.create(pet_id: pet2.id)
+
+      expect(application.application_rejected?).to eq(false)
+
+      app_pet1.update(status: 1)
+
+      expect(application.application_rejected?).to eq(false)
+
+      app_pet2.update(status: 2)
+
+      expect(application.application_rejected?).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
Added feature to dynamically approve or reject an application based on the approval or rejection of associated application pets.
---
- Add feature test for full application approval when all application pets approved
- Add model test for #application_approved?
- Add #application_approved?
- Add application info to admin application show view
- Update update action to approve full application when all pets approved
- Add feature test for application rejection when one or more pets are not approved
- Add model test for #application_rejected?
- Add #application_rejected?
- Update update with application rejection if any pets are rejected