### PR TITLE
Admin

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,8 +7,10 @@ class AdminController < ApplicationController
     @application = Application.find(params[:app_id])
     app_pet = @application.application_pets.find(params[:pet_id])
     app_pet.update(status: params[:status].to_i)
-
-    @application.update(status: 2) if @application.application_approved?
+    if @application.application_approved?
+      @application.update(status: 2)
+      @application.pets.update_all(status: 2)
+    end
     @application.update(status: 3) if @application.application_rejected?
 
     redirect_to "/admin/applications/#{params[:app_id]}"

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -8,11 +8,15 @@
 <% @application.application_pets.each do |application_pet| %>
   <li id='pet-application-status-<%= application_pet.pet.id %>'>
     <%= content_tag :p, application_pet.pet.name %>
-    <% if application_pet.status == 'pending'  %>
+    <% if application_pet.status != "pending" %>
+      <%= application_pet.status %>
+    <% elsif application_pet.pet.status == "adopted" %>
+      <p>This pet has already been approved for adoption.</p>
+    <% elsif application_pet.status == 'pending' %>
       <%= button_to "Approve Pet", "/admin/application/#{@application.id}/application_pets/#{application_pet.id}", method: :patch, params: {status: 1} %>
       <%= button_to "Reject Pet", "/admin/application/#{@application.id}/application_pets/#{application_pet.id}", method: :patch, params: {status: 2} %>
     <% else %>
-      <%= application_pet.status %>
+      <img src="https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fi.imgflip.com%2F4j456x.jpg">
     <% end %>
   </li>
 <% end %>

--- a/spec/features/admin/application_show_spec.rb
+++ b/spec/features/admin/application_show_spec.rb
@@ -84,5 +84,39 @@ describe "As a visitor" do
         expect(page).to have_content("Status: rejected")
       end
     end
+    describe "When a pet has and approved application on them" do
+      describe "I as an admin cannot approve or reject them for another app" do
+        it "And I see a message telling me that this pet has been approved for adoption" do
+          @user2 = User.create!(name: "John Doe", address: "123 candy cane lane", city: "Denver", state: "Colorado", zip: "80128")
+          @application2 = @user2.applications.create(description: "Just cuz", status: 1)
+          @application2.application_pets.create([{pet_id: @pet1.id}, {pet_id: @pet2.id}])
+          expect(page).to have_content("Status: pending")
+
+          within("#pet-application-status-#{@pet1.id}") do
+            click_button "Approve Pet"
+          end
+
+          expect(page).to have_content("Status: pending")
+
+          within("#pet-application-status-#{@pet2.id}") do
+            click_button "Approve Pet"
+          end
+
+          expect(page).to have_content("Status: approved")
+
+          visit "/admin/applications/#{@application2.id}"
+
+          within("#pet-application-status-#{@pet1.id}") do
+            expect(page).to_not have_button("Approve Pet")
+            expect(page).to have_content("This pet has already been approved for adoption")
+          end
+
+          within("#pet-application-status-#{@pet2.id}") do
+            expect(page).to_not have_button("Approve Pet")
+            expect(page).to have_content("This pet has already been approved for adoption")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Add feature to not allow an admin to approve the same pet twice

- Add test to not allow admin to approve adopted pet
- Update If logic for when a pet has already been adopted
- Update the update action to update a pets adoption status website wide if application was approved