### PR TITLE
Add feature to prevent deletion of shelters with approved apps

### DIFF
--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -18,4 +18,8 @@ class Shelter < ApplicationRecord
   def app_count
     applications.distinct.count
   end
+
+  def deletable?
+    applications.pluck(:status).none?('approved')
+  end
 end

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -5,7 +5,9 @@
 <section class="shelter-<%= shelter.id %>">
   <%= link_to "#{shelter.name}", "/shelters/#{shelter.id}" %><br>
   <%= link_to "Update Shelter", "/shelters/#{shelter.id}/edit" %>
-  <%= link_to "Delete Shelter", "/shelters/#{shelter.id}", method: :delete %><br><br>
+  <% if shelter.deletable? %>
+    <%= link_to "Delete Shelter", "/shelters/#{shelter.id}", method: :delete %><br><br>
+  <% end %>
 </section>
 <% end %>
 <%= link_to "New Shelter", "/shelters/new" %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -21,7 +21,9 @@
   </section>
 <% end %>
 <%= link_to "Update Shelter", "/shelters/#{@shelter.id}/edit" %><br>
-<%= link_to "Delete Shelter", "/shelters/#{@shelter.id}", method: :delete %><br>
+<% if @shelter.deletable? %>
+  <%= link_to "Delete Shelter", "/shelters/#{@shelter.id}", method: :delete %><br>
+<% end %>
 <%= link_to "Pets", "/shelters/#{@shelter.id}/pets" %><br>
 <%= link_to "Add Review", "/shelters/#{@shelter.id}/reviews/new" %><br>
 </main>

--- a/spec/features/shelters/delete_spec.rb
+++ b/spec/features/shelters/delete_spec.rb
@@ -27,5 +27,29 @@ describe "As a visitor" do
 
       expect(page).to_not have_content(shelter_2.name)
     end
+    it "I can't delete a shelter that has pets approved for adoption" do
+      user = User.create!(name: "Tim Tyrell", address: "321 you hate to see it dr", city: "Denver", state: "Colorado", zip: "80000")
+      shelter = Shelter.create(name: "Van's pet shop", address: "3724 tennessee dr", city: "Rockford", state: "Illinois", zip: "61108")
+      pet = shelter.pets.create(image: "https://static.insider.com/image/5d24d6b921a861093e71fef3.jpg", name: "Maisy", age: "6", sex: "female", description: "Stomache on legs", status: 0)
+      application = user.applications.create(description: "I'm awesome, give me animals.", status: 1)
+      application.application_pets.create(pet_id: pet.id)
+
+      visit "/shelters/#{shelter.id}"
+      expect(page).to have_link("Delete Shelter")
+
+      visit "/shelters"
+      expect(page).to have_link("Delete Shelter")
+
+      visit "admin/applications/#{application.id}"
+      within("#pet-application-status-#{pet.id}") do
+        click_button "Approve Pet"
+      end
+
+      visit "/shelters/#{shelter.id}"
+      expect(page).to_not have_link("Delete Shelter")
+
+      visit "/shelters"
+      expect(page).to_not have_link("Delete Shelter")
+    end
   end
 end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -12,6 +12,7 @@ describe Shelter, type: :model do
   describe "relationships" do
     it { should have_many :pets }
     it { should have_many :reviews }
+    it { should have_many(:applications).through(:pets) }
   end
 
   describe "instance methods" do
@@ -58,6 +59,19 @@ describe Shelter, type: :model do
       expect(shelter1.app_count).to eq(2)
       expect(shelter2.app_count).to eq(1)
       expect(shelter3.app_count).to eq(0)
+    end
+    it "#deletable?" do
+      user = User.create!(name: "Tim Tyrell", address: "321 you hate to see it dr", city: "Denver", state: "Colorado", zip: "80000")
+      shelter = Shelter.create(name: "Van's pet shop", address: "3724 tennessee dr", city: "Rockford", state: "Illinois", zip: "61108")
+      pet = shelter.pets.create(image: "https://static.insider.com/image/5d24d6b921a861093e71fef3.jpg", name: "Maisy", age: "6", sex: "female", description: "Stomache on legs", status: 0)
+      application = user.applications.create(description: "I'm awesome, give me animals.", status: 1)
+      application.application_pets.create(pet_id: pet.id)
+
+      expect(shelter.deletable?).to eq(true)
+
+      application.update(status: 2)
+
+      expect(shelter.deletable?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Added feature to prevent deletion of shelters that have approved applications.
---
- Add feature tests for hiding 'Delete Shelter' links for shelters with approved applications
- Update relationship tests and add model test for #deletable?
- Add #deletable?
- Add logic to hide 'Delete Shelter' link if shelter has an approved application