### PR TITLE
Add feature pets with approved applications cannot be deleted

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,4 +8,9 @@ class ApplicationRecord < ActiveRecord::Base
     end
     avg.to_f
   end
+
+  def deletable?
+    applications.pluck(:status).none?('approved')
+  end
+
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -19,10 +19,6 @@ class Shelter < ApplicationRecord
     applications.distinct.count
   end
 
-  def deletable?
-    applications.pluck(:status).none?('approved')
-  end
-
   def delete_pets
     pets.each do |pet|
       pet.applications.clear

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -9,7 +9,9 @@
       <p>Sex: <%= pet.sex %></p>
       <p>Belongs To: <%= link_to "#{pet.shelter.name}", "/shelters/#{pet.shelter.id}" %></p>
       <%= link_to "Update Pet", "/pets/#{pet.id}/edit" %><br>
-      <%= link_to "Delete Pet", "/pets/#{pet.id}/delete", method: :delete %><br><br>
+      <% if pet.deletable? %>
+        <%= link_to "Delete Pet", "/pets/#{pet.id}/delete", method: :delete %><br><br>
+      <% end %>
     </section>
   <% end %>
   <%= link_to "Start an Application", "/applications/new" %>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -8,7 +8,9 @@
 <p>Sex: <%= @pet.sex %></p>
 <p>Adoption status: <%= @pet.status %></p>
 <%= link_to "Update Pet", "/pets/#{@pet.id}/edit" %><br>
-<%= link_to "Delete Pet", "/pets/#{@pet.id}/delete", method: :delete %><br>
+<% if @pet.deletable? %>
+  <%= link_to "Delete Pet", "/pets/#{@pet.id}/delete", method: :delete %><br>
+<% end %>
 <%= link_to "Applications for #{@pet.name}", "/pets/#{@pet.id}/applications" %>
 
 </main>

--- a/app/views/shelters/pets.html.erb
+++ b/app/views/shelters/pets.html.erb
@@ -10,7 +10,9 @@
   <h3>Sex: <%= pet.sex %></h3>
   <h3>Adoption Status: <%= pet.status %></h3>
   <%= link_to "Update Pet", "/pets/#{pet.id}/edit" %><br>
-  <%= link_to "Delete Pet", "/pets/#{pet.id}/delete", method: :delete %><br><br>
+  <% if pet.deletable? %>
+    <%= link_to "Delete Pet", "/pets/#{pet.id}/delete", method: :delete %><br><br>
+  <% end %>
   </section>
 <% end %>
 <%= link_to 'Create Pet', "/shelters/#{@shelter.id}/pets/new" %>

--- a/spec/features/pets/delete_spec.rb
+++ b/spec/features/pets/delete_spec.rb
@@ -16,5 +16,33 @@ describe "as a visitor" do
       expect(current_path).to eq("/pets")
       expect(page).to_not have_content(pet1.name)
     end
+    it "If a pet has an approved application on them, the delete links for that pet will no longer be visible" do
+      shelter = Shelter.create(name: "Van's pet shop", address: "3724 tennessee dr", city: "Rockford", state: "Illinois", zip: "61108")
+      pet = shelter.pets.create(image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", name: "Bella", age: "5", sex: "female", description: "Fun Loving Dog", status: 0)
+      user = User.create!(name: "Tim Tyrell", address: "321 you hate to see it dr", city: "Denver", state: "Colorado", zip: "80000")
+      application = user.applications.create(description: "I'm awesome, give me animals.", status: 1)
+      application.application_pets.create({pet_id: pet.id})
+
+      visit "/shelters/#{shelter.id}/pets"
+      expect(page).to have_link("Delete Pet")
+
+      visit "/pets"
+      expect(page).to have_link("Delete Pet")
+
+      visit "/pets/#{pet.id}"
+      expect(page).to have_link("Delete Pet")
+
+      application.update(status: 2)
+      pet.update(status: 2)
+
+      visit "/shelters/#{shelter.id}/pets"
+      expect(page).to_not have_link("Delete Pet")
+
+      visit "/pets"
+      expect(page).to_not have_link("Delete Pet")
+
+      visit "/pets/#{pet.id}"
+      expect(page).to_not have_link("Delete Pet")
+    end
   end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -27,4 +27,21 @@ describe Pet, type: :model do
       expect(Pet.search("f")).to eq([pet4, pet5])
     end
   end
+
+  describe "instance methods" do
+    it "#deletable?" do
+      shelter = Shelter.create(name: "Van's pet shop", address: "3724 tennessee dr", city: "Rockford", state: "Illinois", zip: "61108")
+      pet = shelter.pets.create(image: "https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/dog_cool_summer_slideshow/1800x1200_dog_cool_summer_other.jpg", name: "Bella", age: "5", sex: "female", description: "Fun Loving Dog", status: 0)
+      user = User.create!(name: "Tim Tyrell", address: "321 you hate to see it dr", city: "Denver", state: "Colorado", zip: "80000")
+      application = user.applications.create(description: "I'm awesome, give me animals.", status: 1)
+      application.application_pets.create({pet_id: pet.id})
+
+      expect(pet.deletable?).to eq(true)
+
+      application.update(status: 2)
+      pet.update(status: 2)
+
+      expect(pet.deletable?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Added feature to remove delete button when a pet is associated with an approved application.
---
- Add feature tests for hiding "Delete Pet" when pet has approved application
- Add model test for #deletable?
- Extract #deletable? from shelter and pet to application_record
- Add feature to hide "Delete Pet" for pets that have an approved application