### PR TITLE
Extentions

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -35,7 +35,12 @@ class ReviewsController < ApplicationController
 
   private
   def review_params
-    params.permit(:title, :rating, :content, :image, :shelter_id, :user_id)
+    default_image = "https://media3.giphy.com/media/o0vwzuFwCGAFO/giphy.gif?cid=790b761143794a0c3a7b311e04b4bbf2966d12685520db43&rid=giphy.gif"
+    if params[:image] != ""
+      params.permit(:title, :rating, :content, :image, :shelter_id, :user_id)
+    else
+      params.permit(:title, :rating, :content, :shelter_id, :user_id).merge({image: default_image})
+    end
   end
 
   def shelter
@@ -48,6 +53,9 @@ class ReviewsController < ApplicationController
 
   def save_review(user)
     @review = user.reviews.new(review_params)
+    if review_params[:image] == ""
+      review_params[:image] = default_image
+    end
     if @review.save
       redirect_to "/shelters/#{params[:shelter_id]}"
     else

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -35,7 +35,7 @@ class ReviewsController < ApplicationController
 
   private
   def review_params
-    params.permit(:title, :rating, :content, :shelter_id, :user_id)
+    params.permit(:title, :rating, :content, :image, :shelter_id, :user_id)
   end
 
   def shelter

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,20 +1,20 @@
 <h1>Edit Review</h1>
 
 <%= form_tag("/shelters/#{@review.shelter_id}/reviews/#{@review.id}", method: :patch) do %>
-  <%= label_tag :title %>
-  <%= text_field_tag :title, value="#{@review.title}" %>
+  <%= label_tag :title %><br>
+  <%= text_field_tag :title, value="#{@review.title}" %><br>
 
-  <%= label_tag :rating %>
-  <%= text_field_tag :rating, value="#{@review.rating}" %>
+  <%= label_tag :rating %><br>
+  <%= text_field_tag :rating, value="#{@review.rating}" %><br>
 
-  <%= label_tag :content %>
-  <%= text_field_tag :content, value="#{@review.content}" %>
+  <%= label_tag :content %><br>
+  <%= text_field_tag :content, value="#{@review.content}" %><br>
 
-  <%= label_tag :image %>
-  <%= text_field_tag :image, value="#{@review.image}" %>
+  <%= label_tag :image %><br>
+  <%= text_field_tag :image, value="#{@review.image}" %><br>
 
-  <%= label_tag :user %>
-  <%= text_field_tag :user, value="#{@review.user.name}" %>
+  <%= label_tag :user %><br>
+  <%= text_field_tag :user, value="#{@review.user.name}" %><br>
 
   <%= submit_tag "Update Review" %>
 <% end %>

--- a/spec/features/reviews/new_spec.rb
+++ b/spec/features/reviews/new_spec.rb
@@ -34,6 +34,23 @@ describe "as a visitor" do
         expect(page).to have_content("5")
         expect(page).to have_content("This place has everything you need")
         expect(page).to have_content("#{user.name}")
+        expect(page).to have_xpath("//img[@src='https://media3.giphy.com/media/o0vwzuFwCGAFO/giphy.gif?cid=790b761143794a0c3a7b311e04b4bbf2966d12685520db43&rid=giphy.gif']")
+
+        visit "/shelters/#{shelter2.id}"
+
+        click_link "Add Review"
+
+        fill_in "Title", with: "This place rocks"
+        fill_in "Rating", with: "5"
+        fill_in "Content", with: "This place has everything you need"
+        fill_in "Name", with: "#{user.name}"
+        fill_in "Image", with: "https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcTMGwI5inesDaT4zWtwKPvk0jvMyY2NT7lBrg&usqp=CAU"
+
+        click_on "Add Review"
+
+        expect(page).to_not have_xpath("//img[@src='https://media3.giphy.com/media/o0vwzuFwCGAFO/giphy.gif?cid=790b761143794a0c3a7b311e04b4bbf2966d12685520db43&rid=giphy.gif']")
+        expect(page).to have_xpath("//img[@src='https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcTMGwI5inesDaT4zWtwKPvk0jvMyY2NT7lBrg&usqp=CAU']")
+
       end
       it "I fail to fill in the form correctly and it displays a flash message" do
         shelter1 = create(:shelter)


### PR DESCRIPTION
Add feature If a user does not provide an image for a review one is provided for them

- Add image to review params to allow a user to submit a review with an image
- Update test for a default image for a review
- Add new lines to form for a better layout
- Update strong params for a default image for reviews